### PR TITLE
Removed dead link

### DIFF
--- a/topic_folders/workshop_administration/workshop_admin_workflow.md
+++ b/topic_folders/workshop_administration/workshop_admin_workflow.md
@@ -46,7 +46,7 @@
 
 1. After workshop is over Workshop Administrator sends email asking how things went and collecting attendance data.
 
-1. Workshop Administrator records workshop attendance in AMY, and if additional information is provided, in the [Workshop Documents github repo](https://github.com/swcarpentry/workshop_documents).
+1. Workshop Administrator records workshop attendance in AMY
 
 
 #### For self organized workshops
@@ -69,4 +69,4 @@
 
 1. After workshop is over Workshop Administrator sends email asking how things went and collecting attendance data.
 
-1. Workshop Administrator records workshop attendance in AMY, and if additional information is provided, in the [Workshop Documents github repo](https://github.com/swcarpentry/workshop_documents).
+1. Workshop Administrator records workshop attendance in AMY


### PR DESCRIPTION
The following repo, which is referenced in the workshop admin notes, doesn't exist:
https://github.com/swcarpentry/workshop_documents