### PR TITLE
Updated reimbursement policy on submission timeline

### DIFF
--- a/topic_folders/policies/reimbursement-policy.md
+++ b/topic_folders/policies/reimbursement-policy.md
@@ -88,6 +88,7 @@ Reimbursement requests should be approved by the Executive Director or the Execu
 - Executive Council Treasurer - Sue McClatchy
 
 #### VII. Update Log
+- Updated on 2018-03-06 to reflect that reimbursements cannot be denied due their time of submission.
 - Updated on 2018-02-23 to reflect updated workflow with Community Initiatives and approval contacts.
 - Updated on 2018-01-31 to refer to Community Initiatives as our fiscal sponsor.
 - Updated 2017-12-22 to change from Data Carpentry to The Carpentries.

--- a/topic_folders/policies/reimbursement-policy.md
+++ b/topic_folders/policies/reimbursement-policy.md
@@ -56,7 +56,7 @@ DEADLINE TO SUBMIT EXPENSE REPORTS AND DOCUMENTATION
 *Expense Reimbursement Deadlines*  
 To be reimbursable, business expenses must be properly substantiated and submitted within certain time limitations.
 - Substantiation for the reimbursement should be submitted within **60 calendar days** of when the expenses were incurred. For expenses incurred while traveling, the traveler will have 60 calendar days upon returning from travel to substantiate and submit the expenses.
-- If substantiation occurs more than 60 calendar days after the expenses were incurred, the expense reimbursement request must include an explanation for the delay. The Carpentries may deny reimbursement requests submitted or substantiated after the 60-day limit.
+- If substantiation occurs more than 60 calendar days after the expenses were incurred, the expense reimbursement request must include an explanation for the delay.
 - Funds can be reimbursed before travel is completed, with receipts for the travel expenditure. If travel is not completed or is changed to have a lower cost, funds must be returned according to the 'Return of Excess Amounts' section.
 
 RETURN OF EXCESS AMOUNTS  


### PR DESCRIPTION
Updated the policy to take out the line that reimbursements can be denied if past the 60 day limit. 

Per CI attorney, the standard is that "unless an employee has waited more than 4 years (the statue of limitations for "indemnification" from an employer) reimbursements should not be denied based on time of submission.